### PR TITLE
Use pcall varargs to pass parameter to require

### DIFF
--- a/hate/init.lua
+++ b/hate/init.lua
@@ -207,7 +207,7 @@ function hate.init()
 		hate.state.running = false
 	end
 
-	pcall(function() require "conf" end)
+	pcall(require, "conf")
 
 	local config = {
 		name       = "hate",


### PR DESCRIPTION
pcall supports varargs for function arguments; why create a new function if you don't have to?

On that note, shouldn't a syntax error in conf throw an error? I'm not sure how LOVE handles that.